### PR TITLE
add code templates to runCode()

### DIFF
--- a/cmd/dev/eval.ts
+++ b/cmd/dev/eval.ts
@@ -23,7 +23,6 @@ export default class extends Cmd {
 		const firstArg = args[0].split('-')
 		const lang = langs.includes(firstArg[0]) ? args.shift()?.split('-')[0] as Lang : 'eval'
 		const template = (firstArg[1] ?? '')
-		console.log(args.join(' '))
 
 		const startTime = Date.now() // start time for execution duration
 		let output = '' // output of the code execution

--- a/cmd/dev/eval.ts
+++ b/cmd/dev/eval.ts
@@ -20,7 +20,11 @@ export default class extends Cmd {
 		// all supported programming languages
 
 		// Language to be runned
-		const lang = langs.includes(args[0]) ? args.shift() as Lang : 'eval'
+		const firstArg = args[0].split('-')
+		const lang = langs.includes(firstArg[0]) ? args.shift()?.split('-')[0] as Lang : 'eval'
+		const template = (firstArg[1] ?? '')
+		console.log(args.join(' '))
+
 		const startTime = Date.now() // start time for execution duration
 		let output = '' // output of the code execution
 
@@ -50,7 +54,7 @@ export default class extends Cmd {
 			output = inspect(evaled, { depth: null })
 			// inspect output: stringify obj to human readable form
 		} else {
-			output = await runCode(lang, args.join(' '))
+			output = await runCode(lang, args.join(' '), undefined, template)
 			// runCode: run on a child process
 		}
 

--- a/conf/defaults.json
+++ b/conf/defaults.json
@@ -24,51 +24,70 @@
 			"cmd": [
 				"conf/venv/bin/python3"
 			],
-			"ext": "py"
+			"ext": "py",
+			"templates": {}
 		},
 		"lua": {
 			"cmd": [
 				"luajit"
 			],
-			"ext": "lua"
+			"ext": "lua",
+			"templates": {}
 		},
 		"node": {
 			"cmd": [
 				"node"
 			],
-			"ext": "js"
+			"ext": "js",
+			"templates": {}
 		},
 		"deno": {
 			"cmd": [
 				"deno run -A"
 			],
-			"ext": "ts"
+			"ext": "ts",
+			"templates": {}
 		},
 		"bun": {
 			"cmd": [
 				"bun run"
 			],
-			"ext": "ts"
+			"ext": "ts",
+			"templates": {}
 		},
 		"fish": {
 			"cmd": [
 				"fish"
 			],
-			"ext": "sh"
+			"ext": "sh",
+			"templates": {}
+		},
+		"zsh": {
+			"cmd": [
+				"zsh"
+			],
+			"ext": "sh",
+			"templates": {}
 		},
 		"cpp": {
 			"cmd": [
 				"g++ -o conf/temp/main ",
 				"./conf/temp/main #"
 			],
-			"ext": "cpp"
+			"ext": "cpp",
+			"templates": {
+				"main": "#include <iostream>\n int main() {\n//__CODE__//\n}"
+			}
 		},
 		"rust": {
 			"cmd": [
-				"rustc -o conf/temp/main ",
-				"./conf/temp/main #"
+				"rustc -o conf/temp/main",
+				"./conf/temp/main"
 			],
-			"ext": "rs"
+			"ext": "rs",
+			"templates": {
+				"main": "fn main() {\n//__CODE__//\n}"
+			}
 		}
 	}
 }

--- a/plugin/runCode.ts
+++ b/plugin/runCode.ts
@@ -15,9 +15,12 @@ export default async function runCode(lang: Lang, code = '', file: str = '', tem
 			data = defaults.runner[lang]
 
 			file = `${defaults.runner.tempFolder}exec.${data.ext}` // file path
-			if (template in data.templates && template != '') { //check if have some template selected
-				code = data.templates[template].replace("//__CODE__//", code)//and replace the placeholder to the code
+
+			if (template in data.templates && template != '') { //check if have some valid template selected
+				code = (data.templates as Record<string, string>)[template].replace("//__CODE__//", code)
+				//and replace the placeholder to the code
 			}
+
 			await writeFile(file, code) // write file
 			code = ''
 			// don't write code in CLI to prevent issues
@@ -38,3 +41,7 @@ export default async function runCode(lang: Lang, code = '', file: str = '', tem
 			.replace(new RegExp(regex, 'gi'), '') // remove cli from error msg
 	}
 }
+//    ___
+//   (o o)        linksyyy pass here
+//   ( V )
+///--m - m---------\

--- a/plugin/runCode.ts
+++ b/plugin/runCode.ts
@@ -2,7 +2,7 @@ import defaults from '../conf/defaults.json' with { type: 'json' }
 import { execSync } from 'node:child_process'
 import { writeFile } from 'node:fs/promises'
 
-export default async function runCode(lang: Lang, code = '', file: str = '') {
+export default async function runCode(lang: Lang, code = '', file: str = '', template: str = '') {
 	const cli: str[] = []
 	let data
 
@@ -15,11 +15,13 @@ export default async function runCode(lang: Lang, code = '', file: str = '') {
 			data = defaults.runner[lang]
 
 			file = `${defaults.runner.tempFolder}exec.${data.ext}` // file path
+			if (template in data.templates && template != '') { //check if have some template selected
+				code = data.templates[template].replace("//__CODE__//", code)//and replace the placeholder to the code
+			}
 			await writeFile(file, code) // write file
 			code = ''
 			// don't write code in CLI to prevent issues
 		}
-
 		let output = ''
 		for (const i in data.cmd) {
 			cli[i] = `${data.cmd[i]} ${file} ${code}` // save CLIs
@@ -28,9 +30,9 @@ export default async function runCode(lang: Lang, code = '', file: str = '') {
 		}
 		return output
 	} catch (e: any) {
+
 		// remove some chars that can conflict with regex chars
 		const regex = `(${cli.join('|').filterForRegex()})`
-
 		return String(e?.message || e)
 			.replace(`Command failed: `, '') // clean errors
 			.replace(new RegExp(regex, 'gi'), '') // remove cli from error msg


### PR DESCRIPTION
Implemented support for language-specific code templates in runCode().

- Added parsing of optional template identifiers from command arguments.

- Updated defaults.json to define templates for C++ and Rust.

- Modified runCode() to insert user code into the selected template before execution.

- Adjusted function signatures and execution flow to handle the new template parameter.